### PR TITLE
Fix action for personal repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Saves lists of changed files in the `outputs` object and on the filesystem for u
 ```
 - use: lots0logs/gh-action-get-changed-files@2.0.5
   with:
-    token: YOUR_PERSONAL_ACCESS_TOKEN
+    token: GITHUB_TOKEN
 ```
 
 ### Inputs
-* **`token`**: GitHub Personal Access Token
+* **`token`**: [The `GITHUB_TOKEN` secret](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token).
 
 ### Outputs
 All output values are a single JSON encoded array.

--- a/main.js
+++ b/main.js
@@ -3,10 +3,10 @@ const fs                  = require('fs');
 const { context, GitHub } = require('@actions/github');
 const core                = require('@actions/core');
 
-
 const commits = context.payload.commits.filter(c => c.distinct);
-const repo    = context.payload.repository.name;
-const org     = context.payload.repository.organization;
+const repo    = context.payload.repository;
+const org     = repo.organization;
+const owner   = org || repo.owner;
 
 const FILES          = [];
 const FILES_MODIFIED = [];
@@ -14,7 +14,7 @@ const FILES_ADDED    = [];
 const FILES_DELETED  = [];
 
 const gh   = new GitHub(core.getInput('token'));
-const args = { owner: org, repo };
+const args = { owner: owner.name, repo: repo.name };
 
 function isAdded(file) {
 	return 'added' === file.status;


### PR DESCRIPTION
I noticed if a repo was not part of an organization then this action would fail.
Also changed the language in the readme a little bit to avoid confusion with GitHub's OAuth personal access tokens. I believe the token used with GitHub Actions is similar to a GitHub App token and not a personal access token. Some companies won't let employees generate personal access tokens because of the broad scopes GitHub grants them. But this shouldn't be an issue if folks are just using the `GITHUB_TOKEN` that gets minted by each repo.