### PR TITLE
Added support for pull_request_target event type

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -331,6 +331,7 @@ async function getCommits() {
 			commits = context.payload.commits;
 		break;
 
+    case 'pull_request_target':
 		case 'pull_request':
 			const url = context.payload.pull_request.commits_url;
 
@@ -338,7 +339,7 @@ async function getCommits() {
 		break;
 
 		default:
-			info('You are using this action on an event for which it has not been tested. Only the "push" and "pull_request" events are officially supported.');
+			info('You are using this action on an event for which it has not been tested. Only the "push", "pull_request" and "pull_request_target" events are officially supported.');
 
 			commits = [];
 		break;

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ async function getCommits() {
 		break;
 
 		default:
-			info('You are using this action on an event for which it has not been tested. Only the "push" and "pull_request" events are officially supported.');
+			info('You are using this action on an event for which it has not been tested. Only the "push", "pull_request" and "pull_request_target" events are officially supported.');
 
 			commits = [];
 		break;

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ async function getCommits() {
 			commits = context.payload.commits;
 		break;
 
+		case 'pull_request_target':
 		case 'pull_request':
 			const url = context.payload.pull_request.commits_url;
 


### PR DESCRIPTION
### What do I want to achieve?
I want to use this action for pull requests from forks with using secrets. So I added this other event type which will work because it has the exact same payload. https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target 